### PR TITLE
Move react from dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "away"
   ],
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "react": "^0.14.7",
     "react-dom": "^0.14.7"
   },


### PR DESCRIPTION
I tried using your component and got `Warning: React can't find the root component node for.... If you're seeing this message, it probably means that you've loaded two copies of React on the page. At this time, only a single copy of React can be loaded at a time.` error.

By moving it to peerDependencies, it does not install multiple copies of React in your `node_modules`.
